### PR TITLE
Update lodash to 3.10.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
 	"description": "Utility for moderating listeners for browser events on window",
 	"main": "main.js",
 	"dependencies": {
-		"lodash": "https://github.com/lodash/lodash.git#3.5.0-npm"
+		"lodash": "https://github.com/lodash/lodash.git#3.10.1-npm"
 	}
 }


### PR DESCRIPTION
 to resolve dependency conflicts with n-instrumentation.

As an aside, is there a way to not lock it to a precise version when pulling from github?