### PR TITLE
Allow viewport dimensions to ignore scrollbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Provides a reasonably reliable way (more so than `window.orientation`) of obtain
 Provides a reasonably reliable way of obtaining the current visibility of the viewport.
 
 ### `o-viewport#getSize(ignoreScrollbars)`
-Provides a reliable way of obtaining the current dimensions of the browser window. returns an object with the properties `width` and `height`.
+Provides a reliable way of obtaining the current dimensions of the browser window. Returns an object with the properties `width` and `height`.
 
-By default or if no parameters are passed the method will return the size of the viewport inclusive of the scrollbars. However in certain vases (e.g. adverts) you may want to get the size of the viewport without the scroll bars. In such case pass `true` to the method in order to ignore the scrollbars.
+By default or if no parameters are passed the method will return the size of the viewport inclusive of the scrollbars. However in certain cases (e.g. adverts) you may want to get the size of the viewport without the scroll bars. In such case pass `true` to the method in order to ignore the scrollbars.
 
 
 ### `o-viewport#getScrollPosition()`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Provides a reasonably reliable way (more so than `window.orientation`) of obtain
 ### `o-viewport#getVisibility()`
 Provides a reasonably reliable way of obtaining the current visibility of the viewport.
 
-### `o-viewport#getSize()`
-Provides a reliable way of obtaining the current dimensions of the browser window. returns an object with the properties `width` and `height`
+### `o-viewport#getSize(ignoreScrollbars)`
+Provides a reliable way of obtaining the current dimensions of the browser window. returns an object with the properties `width` and `height`.
+
+By default or if no parameters are passed the method will return the size of the viewport inclusive of the scrollbars. However in certain vases (e.g. adverts) you may want to get the size of the viewport without the scroll bars. In such case pass `true` to the method in order to ignore the scrollbars.
 
 
 ### `o-viewport#getScrollPosition()`

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
+			'http://polyfill.webservices.ft.com/v2/polyfill.js',
 			'test/*.test.js'
 		],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'http://polyfill.webservices.ft.com/v2/polyfill.js',
+			'http://polyfill.webservices.ft.com/v2/polyfill.js?flags=gated',
 			'test/*.test.js'
 		],
 

--- a/package.json
+++ b/package.json
@@ -4,16 +4,17 @@
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1",
-    "webpack": "^1.12.2",
-    "babel-runtime": "5.8.25",
     "babel-loader": "^5.3.2",
-    "imports-loader": "^0.6.4",
+    "babel-runtime": "5.8.25",
     "bower-webpack-plugin": "^0.1.8",
+    "expect.js": "^0.3.1",
+    "imports-loader": "^0.6.4",
     "karma": "^0.13.0",
-    "karma-webpack": "^1.7.0",
     "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
-    "mocha": "^2.1.0"
+    "karma-webpack": "^1.7.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.17.4",
+    "webpack": "^1.12.2"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,8 @@ function getWidth(ignoreScrollbars) {
 
 function getSize(ignoreScrollbars) {
 	return {
-		height: getHeight(ignoreScrollbars),
-		width: getWidth(ignoreScrollbars)
+		height: module.exports.getHeight(ignoreScrollbars),
+		width: module.exports.getWidth(ignoreScrollbars)
 	};
 }
 
@@ -93,6 +93,8 @@ module.exports = {
 		debug = true;
 	},
 	broadcast: broadcast,
+	getWidth: getWidth,
+	getHeight: getHeight,
 	getSize: getSize,
 	getScrollPosition: getScrollPosition,
 	getVisibility: getVisibility,

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,18 +15,18 @@ function broadcast(eventType, data, target) {
 	}));
 }
 
-function getHeight() {
-	return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+function getHeight(ignoreScrollbars) {
+	return ignoreScrollbars ? document.documentElement.clientHeight : Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 }
 
-function getWidth() {
-	return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+function getWidth(ignoreScrollbars) {
+	return ignoreScrollbars ? document.documentElement.clientWidth : Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 }
 
-function getSize() {
+function getSize(ignoreScrollbars) {
 	return {
-		height: getHeight(),
-		width: getWidth()
+		height: getHeight(ignoreScrollbars),
+		width: getWidth(ignoreScrollbars)
 	};
 }
 

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -80,6 +80,22 @@ describe('o-viewport', function() {
 		expect(typeof viewportSize.height).to.be('number');
 	});
 
+	it('should get size the size of the viewport without scrollbars', function() {
+		document.body.insertAdjacentHTML('afterend', '<div class="test-box" style="height:2000px; width:300px;"></div>');
+		const viewportSize = oViewport.getSize();
+		const viewportSizeNoScrollbars = oViewport.getSize(true);
+		expect(typeof viewportSize.width).to.be('number');
+		expect(typeof viewportSize.height).to.be('number');
+		expect(typeof viewportSizeNoScrollbars.width).to.be('number');
+		expect(typeof viewportSizeNoScrollbars.height).to.be('number');
+		expect(viewportSize.width).to.not.be(viewportSizeNoScrollbars.width);
+		expect(viewportSize.height).to.not.be(viewportSizeNoScrollbars.height);
+
+		let testBoxElement = document.querySelector('.test-box');
+		testBoxElement.parentNode.removeChild(testBoxElement);
+
+	});
+
 	it('should get the orientation of the viewport', function() {
 		expect(oViewport.getOrientation() === 'portrait' || oViewport.getOrientation() === 'landscape').to.be(true);
 	});

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -1,8 +1,11 @@
 /*global describe, it, before, after*/
 
 const expect = require('expect.js');
+import sinon from 'imports?define=>false,require=>false!sinon/pkg/sinon.js';
+
 
 const oViewport = require('./../main.js');
+const utils = require('./../src/utils.js');
 
 function isPhantom() {
 	return /PhantomJS/.test(navigator.userAgent);
@@ -80,20 +83,31 @@ describe('o-viewport', function() {
 		expect(typeof viewportSize.height).to.be('number');
 	});
 
-	it('should get size the size of the viewport without scrollbars', function() {
-		document.body.insertAdjacentHTML('afterend', '<div class="test-box" style="height:2000px; width:300px;"></div>');
-		const viewportSize = oViewport.getSize();
+	it('should pass the flag to get width of the viewport without srollbars', function() {
+		let widthSpy = sinon.spy(utils, 'getWidth');
+		let heightSpy = sinon.spy(utils, 'getHeight');
+
 		const viewportSizeNoScrollbars = oViewport.getSize(true);
-		expect(typeof viewportSize.width).to.be('number');
-		expect(typeof viewportSize.height).to.be('number');
 		expect(typeof viewportSizeNoScrollbars.width).to.be('number');
 		expect(typeof viewportSizeNoScrollbars.height).to.be('number');
-		expect(viewportSize.width).to.not.be(viewportSizeNoScrollbars.width);
-		expect(viewportSize.height).to.not.be(viewportSizeNoScrollbars.height);
+		expect(widthSpy.calledWith(true)).to.be(true);
+		expect(heightSpy.calledWith(true)).to.be(true);
+		expect(widthSpy.calledWith(undefined)).to.be(false);
+		expect(heightSpy.calledWith(undefined)).to.be(false)
+		expect(widthSpy.callCount).to.be(1);
+		expect(heightSpy.callCount).to.be(1);
 
-		let testBoxElement = document.querySelector('.test-box');
-		testBoxElement.parentNode.removeChild(testBoxElement);
+		const viewportSize = oViewport.getSize();
+		expect(typeof viewportSize.width).to.be('number');
+		expect(typeof viewportSize.height).to.be('number');
+		expect(widthSpy.calledWith(undefined)).to.be(true);
+		expect(heightSpy.calledWith(undefined)).to.be(true)
+		expect(widthSpy.callCount).to.be(2);
+		expect(heightSpy.callCount).to.be(2);
 
+
+		widthSpy.restore();
+		heightSpy.restore();
 	});
 
 	it('should get the orientation of the viewport', function() {


### PR DESCRIPTION
The use case is specific to advertising as DFP uses the value without the scrollbars, so in oAds that relies on oViewport we need to be able get dimensions without scrollbars too.

Feature is backwards compatible so does not break anything.