### PR TITLE
Stopped using lodash for throttle/debounce

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,5 @@
 	"name": "o-viewport",
 	"description": "Utility for moderating listeners for browser events on window",
 	"main": "main.js",
-	"dependencies": {
-		"lodash": "https://github.com/lodash/lodash.git#3.10.1-npm"
-	}
+	"dependencies": {}
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -74,6 +74,9 @@ module.exports = function(config) {
 							'imports?define=>false'
 						]
 					}
+				],
+				noParse: [
+					/\/sinon\.js/,
 				]
 			},
 			resolve: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -74,9 +74,6 @@ module.exports = function(config) {
 							'imports?define=>false'
 						]
 					}
-				],
-				noParse: [
-					/\/sinon\.js/,
 				]
 			},
 			resolve: {

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 // let debug;
 const utils = require('./src/utils');
-const throttle = require('lodash/function/throttle');
-const debounce = require('lodash/function/debounce');
+const throttle = utils.throttle;
+const debounce = utils.debounce;
 
 const listeners = {};
 const intervals = {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.1.0",
-    "sinon": "^1.17.4",
+    "sinon": "^2.0.0-pre",
     "webpack": "^1.12.2"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,6 +88,35 @@ function getVisibility() {
 	return document[hiddenName];
 }
 
+function debounce (func, wait) {
+	let timeout;
+	return function () {
+		const args = arguments;
+		const later = () => {
+			timeout = null;
+			func.apply(this, args);
+		};
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+	};
+};
+
+function throttle (func, wait) {
+	let timeout;
+	return function () {
+		if (timeout) {
+			return;
+		}
+		const args = arguments;
+		const later = () => {
+			timeout = null;
+			func.apply(this, args);
+		};
+
+		timeout = setTimeout(later, wait);
+	};
+};
+
 module.exports = {
 	debug: function() {
 		debug = true;
@@ -99,5 +128,7 @@ module.exports = {
 	getScrollPosition: getScrollPosition,
 	getVisibility: getVisibility,
 	getOrientation: getOrientation,
-	detectVisiblityAPI: detectVisiblityAPI
+	detectVisiblityAPI: detectVisiblityAPI,
+	throttle: throttle,
+	debounce: debounce
 };

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -26,20 +26,13 @@ describe('o-viewport utils', function () {
 		const throttled = utils.throttle(callback, 100);
 
 		throttled();
+		throttled();
 
 		clock.tick(99);
 		expect(callback.callCount).to.be(0);
 
 		clock.tick(1);
 		expect(callback.callCount).to.be(1);
-
-		throttled();
-
-		clock.tick(99);
-		expect(callback.callCount).to.be(1);
-
-		clock.tick(1);
-		expect(callback.callCount).to.be(2);
 
 		done();
 	});

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -1,8 +1,7 @@
 /*global describe, it, before, after*/
 
 const expect = require('expect.js');
-import sinon from 'imports?define=>false,require=>false!sinon/pkg/sinon.js';
-
+const sinon = require('sinon/pkg/sinon');
 
 const oViewport = require('./../main.js');
 const utils = require('./../src/utils.js');
@@ -11,7 +10,55 @@ function isPhantom() {
 	return /PhantomJS/.test(navigator.userAgent);
 }
 
+describe('o-viewport utils', function () {
+	let clock;
+
+	before(function() {
+		clock = sinon.useFakeTimers();
+	});
+
+	after(function() {
+		clock.restore();
+	});
+
+	it('should throttle callback to every 100ms', function(done) {
+		const callback = sinon.spy();
+		const throttled = utils.throttle(callback, 100);
+
+		throttled();
+
+		clock.tick(99);
+		expect(callback.callCount).to.be(0);
+
+		clock.tick(1);
+		expect(callback.callCount).to.be(1);
+
+		done();
+	});
+
+	it('should debounce callback by 100ms', function(done) {
+		const callback = sinon.spy();
+		const debounced = utils.debounce(callback, 100);
+
+		debounced();
+
+		clock.tick(99);
+		expect(callback.callCount).to.be(0);
+
+		debounced();
+
+		clock.tick(99);
+		expect(callback.callCount).to.be(0);
+
+		clock.tick(1);
+		expect(callback.callCount).to.be(1);
+
+		done();
+	});
+});
+
 describe('o-viewport', function() {
+
 	before(function() {
 		if (isPhantom()) {
 			// hack to make test run in PhantomJS

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -33,6 +33,14 @@ describe('o-viewport utils', function () {
 		clock.tick(1);
 		expect(callback.callCount).to.be(1);
 
+		throttled();
+
+		clock.tick(99);
+		expect(callback.callCount).to.be(1);
+
+		clock.tick(1);
+		expect(callback.callCount).to.be(2);
+
 		done();
 	});
 


### PR DESCRIPTION
@AlbertoElias @onishiweb 

Installing lodash, with its weird version numbers, occasionally causes builds to break, and it's quite easy to get rid of