### PR TITLE
Add back in throttle and debounce

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,7 @@
 // let debug;
 const utils = require('./src/utils');
-const oUtils = require('o-utils');
-const throttle = oUtils.throttle;
-const debounce = oUtils.debounce;
+const throttle = utils.throttle;
+const debounce = utils.debounce;
 
 const listeners = {};
 const intervals = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 /* jshint devel: true */
+const oUtils = require('o-utils');
 
 let debug;
 
@@ -99,5 +100,7 @@ module.exports = {
 	getScrollPosition: getScrollPosition,
 	getVisibility: getVisibility,
 	getOrientation: getOrientation,
-	detectVisiblityAPI: detectVisiblityAPI
+	detectVisiblityAPI: detectVisiblityAPI,
+	debounce: oUtils.debounce,
+	throttle: oUtils.throttle
 };


### PR DESCRIPTION
The breaking version of oViewport was because throttle and debounce had
been removed in favour of the oUtils throttle and debounce.

This as a breaking change is causing dependency conflicts. It didn't
need to be a breaking change, this commit adds back in utils.throttle
and utils.debounce so that we can widen the semver range of things using
it rather than forcing a round of upgrades to breaking changes.