### PR TITLE
Use ES6 module syntax

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // let debug;
-const utils = require('./src/utils');
+import utils = from './src/utils';
 const throttle = utils.throttle;
 const debounce = utils.debounce;
 
@@ -139,7 +139,7 @@ function stopListeningTo(eventType) {
 	}
 }
 
-module.exports = {
+export default {
 	debug: function() {
 		// debug = true;
 		utils.debug();
@@ -151,4 +151,4 @@ module.exports = {
 	getSize: utils.getSize,
 	getScrollPosition: utils.getScrollPosition,
 	getVisibility: utils.getVisibility
-};
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // let debug;
-import utils = from './src/utils';
+import utils from './src/utils';
 const throttle = utils.throttle;
 const debounce = utils.debounce;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 /* jshint devel: true */
-const oUtils = require('o-utils');
+import oUtils from 'o-utils';
 
 let debug;
 
@@ -89,7 +89,7 @@ function getVisibility() {
 	return document[hiddenName];
 }
 
-module.exports = {
+export default {
 	debug: function() {
 		debug = true;
 	},
@@ -103,4 +103,4 @@ module.exports = {
 	detectVisiblityAPI: detectVisiblityAPI,
 	debounce: oUtils.debounce,
 	throttle: oUtils.throttle
-};
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,8 +26,8 @@ function getWidth(ignoreScrollbars) {
 
 function getSize(ignoreScrollbars) {
 	return {
-		height: module.exports.getHeight(ignoreScrollbars),
-		width: module.exports.getWidth(ignoreScrollbars)
+		height: getHeight(ignoreScrollbars),
+		width: getWidth(ignoreScrollbars)
 	};
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 /* jshint devel: true */
-import oUtils from 'o-utils';
+import * as oUtils from 'o-utils';
 
 let debug;
 


### PR DESCRIPTION
This makes this module consistent with most other Origami modules, and makes it easier to use with Rollup.