### PR TITLE
Revert "use ESM insteadof CJS"

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,7 @@
 // let debug;
-import * as utils from './src/utils';
-
-const {
-	debounce,
-	throttle
-} = utils;
+const utils = require('./src/utils');
+const throttle = utils.throttle;
+const debounce = utils.debounce;
 
 const listeners = {};
 const intervals = {
@@ -142,32 +139,16 @@ function stopListeningTo(eventType) {
 	}
 }
 
-function debug () {
-	// debug = true;
-	utils.debug();
-}
-
-export default {
-	debug,
-	listenTo,
-	stopListeningTo,
-	setThrottleInterval,
+module.exports = {
+	debug: function() {
+		// debug = true;
+		utils.debug();
+	},
+	listenTo: listenTo,
+	stopListeningTo: stopListeningTo,
+	setThrottleInterval: setThrottleInterval,
 	getOrientation: utils.getOrientation,
 	getSize: utils.getSize,
 	getScrollPosition: utils.getScrollPosition,
-	getVisibility: utils.getVisibility,
+	getVisibility: utils.getVisibility
 };
-
-export {
-	debug,
-	listenTo,
-	stopListeningTo,
-	setThrottleInterval
-};
-
-export {
-	getOrientation,
-	getSize,
-	getScrollPosition,
-	getVisibility
-} from './src/utils.js';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,5 @@
 /* jshint devel: true */
-import {
-	debounce,
-	throttle
-} from 'o-utils';
+const oUtils = require('o-utils');
 
 let debug;
 
@@ -92,34 +89,18 @@ function getVisibility() {
 	return document[hiddenName];
 }
 
-function enableDebugMode () {
-	debug = true;
-}
-
-export default {
-	debug: enableDebugMode,
-	broadcast,
-	getWidth,
-	getHeight,
-	getSize,
-	getScrollPosition,
-	getVisibility,
-	getOrientation,
-	detectVisiblityAPI,
-	debounce,
-	throttle
-};
-
-export {
-	enableDebugMode as debug,
-	broadcast,
-	getWidth,
-	getHeight,
-	getSize,
-	getScrollPosition,
-	getVisibility,
-	getOrientation,
-	detectVisiblityAPI,
-	debounce,
-	throttle
+module.exports = {
+	debug: function() {
+		debug = true;
+	},
+	broadcast: broadcast,
+	getWidth: getWidth,
+	getHeight: getHeight,
+	getSize: getSize,
+	getScrollPosition: getScrollPosition,
+	getVisibility: getVisibility,
+	getOrientation: getOrientation,
+	detectVisiblityAPI: detectVisiblityAPI,
+	debounce: oUtils.debounce,
+	throttle: oUtils.throttle
 };

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
-import proclaim from 'proclaim';
+const proclaim = require('proclaim');
+const sinon = require('sinon/pkg/sinon');
 
-// import sinon from 'sinon/pkg/sinon';
-import oViewport from './../main.js';
-import utils from './../src/utils.js';
+const oViewport = require('./../main.js');
+const utils = require('./../src/utils.js');
 
 function isPhantom() {
 	return /PhantomJS/.test(navigator.userAgent);
@@ -94,32 +94,32 @@ describe('o-viewport', function() {
 		proclaim.isTypeOf(viewportSize.height, 'number');
 	});
 
-	// it('should pass the flag to get width of the viewport without scrollbars', function() {
-	// 	let widthSpy = sinon.spy(utils, 'getWidth');
-	// 	let heightSpy = sinon.spy(utils, 'getHeight');
+	it('should pass the flag to get width of the viewport without srollbars', function() {
+		let widthSpy = sinon.spy(utils, 'getWidth');
+		let heightSpy = sinon.spy(utils, 'getHeight');
 
-	// 	const viewportSizeNoScrollbars = oViewport.getSize(true);
-	// 	proclaim.isTypeOf(viewportSizeNoScrollbars.width, 'number');
-	// 	proclaim.isTypeOf(viewportSizeNoScrollbars.height, 'number');
-	// 	proclaim.isTrue(widthSpy.calledWith(true));
-	// 	proclaim.isTrue(heightSpy.calledWith(true));
-	// 	proclaim.isFalse(widthSpy.calledWith(undefined));
-	// 	proclaim.isFalse(heightSpy.calledWith(undefined));
-	// 	proclaim.equal(widthSpy.callCount, 1);
-	// 	proclaim.equal(heightSpy.callCount, 1);
+		const viewportSizeNoScrollbars = oViewport.getSize(true);
+		proclaim.isTypeOf(viewportSizeNoScrollbars.width, 'number');
+		proclaim.isTypeOf(viewportSizeNoScrollbars.height, 'number');
+		proclaim.isTrue(widthSpy.calledWith(true));
+		proclaim.isTrue(heightSpy.calledWith(true));
+		proclaim.isFalse(widthSpy.calledWith(undefined));
+		proclaim.isFalse(heightSpy.calledWith(undefined));
+		proclaim.equal(widthSpy.callCount, 1);
+		proclaim.equal(heightSpy.callCount, 1);
 
-	// 	const viewportSize = oViewport.getSize();
-	// 	proclaim.isTypeOf(viewportSize.width, 'number');
-	// 	proclaim.isTypeOf(viewportSize.height, 'number');
-	// 	proclaim.isTrue(widthSpy.calledWith(undefined));
-	// 	proclaim.isTrue(heightSpy.calledWith(undefined));
-	// 	proclaim.equal(widthSpy.callCount, 2);
-	// 	proclaim.equal(heightSpy.callCount, 2);
+		const viewportSize = oViewport.getSize();
+		proclaim.isTypeOf(viewportSize.width, 'number');
+		proclaim.isTypeOf(viewportSize.height, 'number');
+		proclaim.isTrue(widthSpy.calledWith(undefined));
+		proclaim.isTrue(heightSpy.calledWith(undefined));
+		proclaim.equal(widthSpy.callCount, 2);
+		proclaim.equal(heightSpy.callCount, 2);
 
 
-	// 	widthSpy.restore();
-	// 	heightSpy.restore();
-	// });
+		widthSpy.restore();
+		heightSpy.restore();
+	});
 
 	it('should get the orientation of the viewport', function() {
 		proclaim.isTrue(oViewport.getOrientation() === 'portrait' || oViewport.getOrientation() === 'landscape');


### PR DESCRIPTION
Reverts Financial-Times/o-viewport#50