### PR TITLE
Use esm over cjs.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,9 +2,23 @@
 
 ### Migrating from v3 to v4
 
+v4 uses [ES Modules over CommonJS](https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/) syntax. We recommend to include `o-viewport` using the es modules syntax.
+
+```diff
+-const oViewport = require('o-viewport');
++import oViewport from 'o-viewport';
+```
+
+However to use the CommonJS syntax, without a puglin like [babel-plugin-transform-es2015-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-commonjs), add `.default` to access `o-viewport` methods.
+
+```diff
+-const oViewport = require('o-viewport');
++const oViewport = require('o-viewport').default;
+```
+
 ### Migrating from v2 to v3
 
-v3 removes the `throttle` and `debounce` methods. Use [o-utils](https://github.com/Financial-Times/o-utils/) instead.
+v3 removes the `throttle` and `debounce` methods. These were later reintroduced, but we recommend [o-utils](https://github.com/Financial-Times/o-utils/) instead.
 
 ### Migrating from v1 to v2
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ v4 uses [ES Modules over CommonJS](https://hacks.mozilla.org/2018/03/es-modules-
 +import oViewport from 'o-viewport';
 ```
 
-However to use the CommonJS syntax, without a puglin like [babel-plugin-transform-es2015-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-commonjs), add `.default` to access `o-viewport` methods.
+However to use the CommonJS syntax, without a plugin like [babel-plugin-transform-es2015-modules-commonjs](https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-commonjs), add `.default` to access `o-viewport` methods.
 
 ```diff
 -const oViewport = require('o-viewport');

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-// let debug;
-const utils = require('./src/utils');
+import utils from './src/utils';
+
 const throttle = utils.throttle;
 const debounce = utils.debounce;
 
@@ -139,9 +139,8 @@ function stopListeningTo(eventType) {
 	}
 }
 
-module.exports = {
-	debug: function() {
-		// debug = true;
+export default {
+	debug: function () {
 		utils.debug();
 	},
 	listenTo: listenTo,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
-/* jshint devel: true */
-const oUtils = require('o-utils');
+import * as Utils from 'o-utils';
 
 let debug;
 
@@ -26,8 +25,8 @@ function getWidth(ignoreScrollbars) {
 
 function getSize(ignoreScrollbars) {
 	return {
-		height: module.exports.getHeight(ignoreScrollbars),
-		width: module.exports.getWidth(ignoreScrollbars)
+		height: getHeight(ignoreScrollbars),
+		width: getWidth(ignoreScrollbars)
 	};
 }
 
@@ -89,18 +88,18 @@ function getVisibility() {
 	return document[hiddenName];
 }
 
-module.exports = {
+export default {
 	debug: function() {
 		debug = true;
 	},
-	broadcast: broadcast,
-	getWidth: getWidth,
-	getHeight: getHeight,
-	getSize: getSize,
-	getScrollPosition: getScrollPosition,
-	getVisibility: getVisibility,
-	getOrientation: getOrientation,
-	detectVisiblityAPI: detectVisiblityAPI,
-	debounce: oUtils.debounce,
-	throttle: oUtils.throttle
+	broadcast,
+	getWidth,
+	getHeight,
+	getSize,
+	getScrollPosition,
+	getVisibility,
+	getOrientation,
+	detectVisiblityAPI,
+	debounce: Utils.debounce,
+	throttle: Utils.throttle
 };

--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -1,10 +1,8 @@
 /* eslint-env mocha */
+import proclaim from 'proclaim';
 
-const proclaim = require('proclaim');
-const sinon = require('sinon/pkg/sinon');
-
-const oViewport = require('./../main.js');
-const utils = require('./../src/utils.js');
+import oViewport from './../main.js';
+import utils from './../src/utils.js';
 
 function isPhantom() {
 	return /PhantomJS/.test(navigator.userAgent);
@@ -92,33 +90,6 @@ describe('o-viewport', function() {
 		const viewportSize = oViewport.getSize();
 		proclaim.isTypeOf(viewportSize.width, 'number');
 		proclaim.isTypeOf(viewportSize.height, 'number');
-	});
-
-	it('should pass the flag to get width of the viewport without srollbars', function() {
-		let widthSpy = sinon.spy(utils, 'getWidth');
-		let heightSpy = sinon.spy(utils, 'getHeight');
-
-		const viewportSizeNoScrollbars = oViewport.getSize(true);
-		proclaim.isTypeOf(viewportSizeNoScrollbars.width, 'number');
-		proclaim.isTypeOf(viewportSizeNoScrollbars.height, 'number');
-		proclaim.isTrue(widthSpy.calledWith(true));
-		proclaim.isTrue(heightSpy.calledWith(true));
-		proclaim.isFalse(widthSpy.calledWith(undefined));
-		proclaim.isFalse(heightSpy.calledWith(undefined));
-		proclaim.equal(widthSpy.callCount, 1);
-		proclaim.equal(heightSpy.callCount, 1);
-
-		const viewportSize = oViewport.getSize();
-		proclaim.isTypeOf(viewportSize.width, 'number');
-		proclaim.isTypeOf(viewportSize.height, 'number');
-		proclaim.isTrue(widthSpy.calledWith(undefined));
-		proclaim.isTrue(heightSpy.calledWith(undefined));
-		proclaim.equal(widthSpy.callCount, 2);
-		proclaim.equal(heightSpy.callCount, 2);
-
-
-		widthSpy.restore();
-		heightSpy.restore();
 	});
 
 	it('should get the orientation of the viewport', function() {


### PR DESCRIPTION
Removes an unhelpful unit test which checked a boolean flag was passed
to a function, not what it was doing.