### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/viewport.test.js
+++ b/test/viewport.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
+/* global proclaim */
 
 import oViewport from './../main.js';
 import utils from './../src/utils.js';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.